### PR TITLE
Fix off-by-one in log format handling

### DIFF
--- a/src/Syslog.cpp
+++ b/src/Syslog.cpp
@@ -92,7 +92,7 @@ bool Syslog::vlogf(uint16_t pri, const char *fmt, va_list args) {
 
   message = new char[initialLen + 1];
 
-  len = vsnprintf(message, initialLen, fmt, args);
+  len = vsnprintf(message, initialLen + 1, fmt, args);
   if (len > initialLen) {
     delete[] message;
     message = new char[len + 1];


### PR DESCRIPTION
The length that vsnprintf takes is including the termination char.
Giving only the strlen() result leads to truncated results where there
is always the last char missing.