### PR TITLE
Remove SYSLOG_FMT_BUFFER_SIZE references

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,6 @@ Syslog syslog(udpClient, SYSLOG_PROTO_BSD);
    `TIMESTAMP` field is completely ommited. Syslog server should use a time
    of receiving message in this case. It is OK in most cases. This issue will be
    fixed in some of the next releases.
- - The `logf`/`vlogf` functions allocate formatting buffer for `80` chars. If you
-   need more or less, please change `SYSLOG_FMT_BUFFER_SIZE` in `Syslog.h`
    
 
 [IETF (RFC 5424)]: https://tools.ietf.org/html/rfc5424

--- a/examples/AdvancedLogging/AdvancedLogging.ino
+++ b/examples/AdvancedLogging/AdvancedLogging.ino
@@ -70,10 +70,7 @@ void loop() {
   // syslog.
   syslog.log(LOG_INFO, "Begin loop");
 
-  // Log message can be formated like with printf function, but result message 
-  // can have 80 chars max. This limitation is because of low RAM in some 
-  // hardware. Anyway this can be easily increased or decreased. Search 
-  // SYSLOG_FMT_BUFFER_SIZE in Syslog.h.
+  // Log message can be formated like with printf function.
   syslog.logf(LOG_ERR,  "This is error message no. %d", iteration);
   syslog.logf(LOG_INFO, "This is info message no. %d", iteration);
 

--- a/examples/AdvancedLoggingESP8266/AdvancedLoggingESP8266.ino
+++ b/examples/AdvancedLoggingESP8266/AdvancedLoggingESP8266.ino
@@ -72,10 +72,7 @@ void loop() {
   // syslog.
   syslog.log(LOG_INFO, "Begin loop");
 
-  // Log message can be formated like with printf function, but result message 
-  // can have 80 chars max. This limitation is because of low RAM in some 
-  // hardware. Anyway this can be easily increased or decreased. Search 
-  // SYSLOG_FMT_BUFFER_SIZE in Syslog.h.
+  // Log message can be formated like with printf function.
   syslog.logf(LOG_ERR,  "This is error message no. %d", iteration);
   syslog.logf(LOG_INFO, "This is info message no. %d", iteration);
 

--- a/examples/SimpleLogging/SimpleLogging.ino
+++ b/examples/SimpleLogging/SimpleLogging.ino
@@ -62,10 +62,7 @@ void loop() {
   // syslog.
   syslog.log(LOG_INFO, "Begin loop");
 
-  // Log message can be formated like with printf function, but result message 
-  // can have 80 chars max. This limitation is because of low RAM in some 
-  // hardware. Anyway this can be easily increased or decreased. Search 
-  // SYSLOG_FMT_BUFFER_SIZE in Syslog.h.
+  // Log message can be formated like with printf function.
   syslog.logf(LOG_ERR,  "This is error message no. %d", iteration);
   syslog.logf(LOG_INFO, "This is info message no. %d", iteration);
 

--- a/examples/SimpleLoggingESP8266/SimpleLoggingESP8266.ino
+++ b/examples/SimpleLoggingESP8266/SimpleLoggingESP8266.ino
@@ -63,10 +63,7 @@ void loop() {
   // syslog.
   syslog.log(LOG_INFO, "Begin loop");
 
-  // Log message can be formated like with printf function, but result message 
-  // can have 80 chars max. This limitation is because of low RAM in some 
-  // hardware. Anyway this can be easily increased or decreased. Search 
-  // SYSLOG_FMT_BUFFER_SIZE in Syslog.h.
+  // Log message can be formated like with printf function.
   syslog.logf(LOG_ERR,  "This is error message no. %d", iteration);
   syslog.logf(LOG_INFO, "This is info message no. %d", iteration);
 

--- a/examples/SimpleLoggingWiFi/SimpleLoggingWiFi.ino
+++ b/examples/SimpleLoggingWiFi/SimpleLoggingWiFi.ino
@@ -80,10 +80,7 @@ void loop() {
   // syslog.
   syslog.log(LOG_INFO, "Begin loop");
 
-  // Log message can be formated like with printf function, but result message 
-  // can have 80 chars max. This limitation is because of low RAM in some 
-  // hardware. Anyway this can be easily increased or decreased. Search 
-  // SYSLOG_FMT_BUFFER_SIZE in Syslog.h.
+  // Log message can be formated like with printf function.
   syslog.logf(LOG_ERR,  "This is error message no. %d", iteration);
   syslog.logf(LOG_INFO, "This is info message no. %d", iteration);
 

--- a/examples/SimpleLoggingWiFi101_MKR1000/SimpleLoggingWiFi101_MKR1000.ino
+++ b/examples/SimpleLoggingWiFi101_MKR1000/SimpleLoggingWiFi101_MKR1000.ino
@@ -75,10 +75,7 @@ void loop() {
   // syslog.
   syslog.log(LOG_INFO, "Begin loop");
 
-  // Log message can be formated like with printf function, but result message 
-  // can have 80 chars max. This limitation is because of low RAM in some 
-  // hardware. Anyway this can be easily increased or decreased. Search 
-  // SYSLOG_FMT_BUFFER_SIZE in Syslog.h.
+  // Log message can be formated like with printf function.
   syslog.logf(LOG_ERR,  "This is error message no. %d", iteration);
   syslog.logf(LOG_INFO, "This is info message no. %d", iteration);
 

--- a/examples/SimpleLoggingYun/SimpleLoggingYun.ino
+++ b/examples/SimpleLoggingYun/SimpleLoggingYun.ino
@@ -50,10 +50,7 @@ void loop() {
   // syslog.
   syslog.log(LOG_INFO, "Begin loop");
 
-  // Log message can be formated like with printf function, but result message 
-  // can have 80 chars max. This limitation is because of low RAM in some 
-  // hardware. Anyway this can be easily increased or decreased. Search 
-  // SYSLOG_FMT_BUFFER_SIZE in Syslog.h.
+  // Log message can be formated like with printf function.
   syslog.logf(LOG_ERR,  "This is error message no. %d", iteration);
   syslog.logf(LOG_INFO, "This is info message no. %d", iteration);
 


### PR DESCRIPTION
Don't tell about SYSLOG_FMT_BUFFER_SIZE. Message buffer is allocated in
accordance with message length since 7f474bb.