### PR TITLE
Example for SimpleLogging for the WiFiNINA library

### DIFF
--- a/examples/SimpleLoggingWiFiNINA/SimpleLoggingWiFiNINA.ino
+++ b/examples/SimpleLoggingWiFiNINA/SimpleLoggingWiFiNINA.ino
@@ -1,0 +1,112 @@
+/*
+ Syslog client: SimpleLoggingWiFiNINA example
+ Demonstrates logging messages to Syslog server in IETF format (rfc5424) in 
+ combination with the WiFiNINA library.
+ For more about Syslog see https://en.wikipedia.org/wiki/Syslog
+ created 12 Aug 2022
+ by Tuc
+ This code is in the public domain.
+ */
+
+#include <SPI.h>
+#include <WiFiNINA.h>
+#include <WiFiUdp.h>
+#include <Syslog.h>
+
+// WIFI credentials
+#define WIFI_SSID "**************"
+#define WIFI_PASS "**************"
+
+// Syslog server connection info
+#define SYSLOG_SERVER "syslog-server"
+#define SYSLOG_PORT 514
+
+// This device info
+#define DEVICE_HOSTNAME "my-device"
+#define APP_NAME "my-app"
+unsigned int localPort = 2390;
+
+int status = WL_IDLE_STATUS;
+
+// A UDP instance to let us send and receive packets over UDP
+WiFiUDP udpClient;
+
+// Create a new syslog instance with LOG_KERN facility
+Syslog syslog(udpClient, SYSLOG_SERVER, SYSLOG_PORT, DEVICE_HOSTNAME, APP_NAME, LOG_KERN);
+
+int iteration = 1;
+
+void setup() {
+  // Open serial communications and wait for port to open:
+  Serial.begin(9600);
+  while (!Serial) {
+    ; // wait for serial port to connect. Needed for native USB port only
+  }
+
+  // check for the presence of the shield:
+  if (WiFi.status() == WL_NO_MODULE) {
+    Serial.println("Communication with WiFi module failed!");
+    // don't continue:
+    while (true);
+  }
+
+  String fv = WiFi.firmwareVersion();
+  if (fv < WIFI_FIRMWARE_LATEST_VERSION) {
+    Serial.println("Please upgrade the firmware");
+  }
+
+  // attempt to connect to Wifi network:
+  while (status != WL_CONNECTED) {
+    Serial.print("Attempting to connect to SSID: ");
+    Serial.println(WIFI_SSID);
+    // Connect to WPA/WPA2 network. Change this line if using open or WEP network:
+    status = WiFi.begin(WIFI_SSID, WIFI_PASS);
+
+    // wait 10 seconds for connection:
+    delay(10000);
+  }
+
+  Serial.println("Connected to wifi");
+  printWifiStatus();
+ 
+  udpClient.begin(localPort);
+}
+
+void loop() {
+  // Severity levels can be found in Syslog.h. They are same like in Linux 
+  // syslog.
+  syslog.log(LOG_INFO, "Begin loop");
+
+  // Log message can be formated like with printf function.
+  syslog.logf(LOG_ERR,  "This is error message no. %d", iteration);
+  syslog.logf(LOG_INFO, "This is info message no. %d", iteration);
+
+  // You can force set facility in pri parameter for this log message. More 
+  // facilities in syslog.h or in Linux syslog documentation.
+  syslog.logf(LOG_DAEMON | LOG_INFO, "This is daemon info message no. %d", 
+    iteration);
+
+  // F() macro is supported too
+  syslog.log(LOG_INFO, F("End loop"));
+  iteration++;
+  
+  // wait ten seconds before sending log message again
+  delay(10000);
+}
+
+void printWifiStatus() {
+  // print the SSID of the network you're attached to:
+  Serial.print("SSID: ");
+  Serial.println(WiFi.SSID());
+
+  // print your WiFi shield's IP address:
+  IPAddress ip = WiFi.localIP();
+  Serial.print("IP Address: ");
+  Serial.println(ip);
+
+  // print the received signal strength:
+  long rssi = WiFi.RSSI();
+  Serial.print("signal strength (RSSI):");
+  Serial.print(rssi);
+  Serial.println(" dBm");
+}


### PR DESCRIPTION
This is an example of the SimpleLogging for the WiFiNINA library. Besides some small changes in setting up the connection, this defines a localport for the additional "begin" command which will initialize the library. Without this, you won't get any output.